### PR TITLE
Abstruct `Result<(), Exception>` with `CoreRsResult<()>` 

### DIFF
--- a/app/demo/examples/action_log.rs
+++ b/app/demo/examples/action_log.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use framework::exception;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::exception::Severity;
 use framework::log;
 use framework::log::ConsoleAppender;
@@ -53,7 +53,7 @@ async fn test_action() {
 }
 
 #[instrument]
-async fn handle_request(success: bool) -> Result<(), Exception> {
+async fn handle_request(success: bool) -> CoreRsResult<()> {
     let span = info_span!("http", test_value = field::Empty, elapsed = field::Empty);
     async {
         info!(request_id = 123, "Processing request,");

--- a/app/demo/examples/error.rs
+++ b/app/demo/examples/error.rs
@@ -1,4 +1,4 @@
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::exception::Severity;
 use framework::validation_error;
 
@@ -9,11 +9,11 @@ pub fn main() {
     println!("{error:?}");
 }
 
-fn test() -> Result<(), Exception> {
+fn test() -> CoreRsResult<()> {
     Err(validation_error!(message = "some field is wrong"))
 }
 
-fn test2() -> Result<(), Exception> {
+fn test2() -> CoreRsResult<()> {
     Err(validation_error!(
         severity = Severity::Error,
         message = "some field is wrong"

--- a/app/demo/examples/kafak_consumer.rs
+++ b/app/demo/examples/kafak_consumer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::kafka::consumer::ConsumerConfig;
 use framework::kafka::consumer::Message;
 use framework::kafka::consumer::MessageConsumer;
@@ -32,7 +32,7 @@ struct Topics {
 }
 
 #[tokio::main]
-pub async fn main() -> Result<(), Exception> {
+pub async fn main() -> CoreRsResult<()> {
     log::init_with_action(ConsoleAppender);
 
     let (tx, rx) = mpsc::channel::<TestMessage>(1000);
@@ -62,7 +62,7 @@ pub async fn main() -> Result<(), Exception> {
     Ok(())
 }
 
-async fn handler_single(state: Arc<State>, message: Message<TestMessage>) -> Result<(), Exception> {
+async fn handler_single(state: Arc<State>, message: Message<TestMessage>) -> CoreRsResult<()> {
     if let Some(ref key) = message.key {
         if key == "1" {
             let value = message.payload()?;
@@ -89,7 +89,7 @@ async fn process_message(mut rx: Receiver<TestMessage>) {
     println!("finished");
 }
 
-async fn handler_bulk(state: Arc<State>, messages: Vec<Message<TestMessage>>) -> Result<(), Exception> {
+async fn handler_bulk(state: Arc<State>, messages: Vec<Message<TestMessage>>) -> CoreRsResult<()> {
     for message in messages {
         if let Some(ref key) = message.key {
             if key == "1" {

--- a/app/demo/examples/kafka_producer.rs
+++ b/app/demo/examples/kafka_producer.rs
@@ -1,4 +1,4 @@
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::kafka::producer::Producer;
 use framework::kafka::topic::Topic;
 use serde::Deserialize;
@@ -10,7 +10,7 @@ struct TestMessage {
 }
 
 #[tokio::main]
-pub async fn main() -> Result<(), Exception> {
+pub async fn main() -> CoreRsResult<()> {
     let producer = Producer::new("dev.internal:9092", env!("CARGO_BIN_NAME"));
 
     let topic = Topic::new("test");

--- a/app/demo/examples/scheduler.rs
+++ b/app/demo/examples/scheduler.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use chrono::FixedOffset;
 use chrono::NaiveTime;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::log;
 use framework::log::ConsoleAppender;
 use framework::schedule::JobContext;
@@ -14,7 +14,7 @@ use tracing::warn;
 struct State {}
 
 #[tokio::main]
-pub async fn main() -> Result<(), Exception> {
+pub async fn main() -> CoreRsResult<()> {
     log::init_with_action(ConsoleAppender);
 
     let shutdown = Shutdown::new();
@@ -26,13 +26,13 @@ pub async fn main() -> Result<(), Exception> {
     scheduler.start(Arc::new(State {}), signal).await
 }
 
-async fn job(_state: Arc<State>, context: JobContext) -> Result<(), Exception> {
+async fn job(_state: Arc<State>, context: JobContext) -> CoreRsResult<()> {
     warn!("test");
     println!("Job executed: {}", context.name);
     Ok(())
 }
 
-async fn daily_job(_state: Arc<State>, context: JobContext) -> Result<(), Exception> {
+async fn daily_job(_state: Arc<State>, context: JobContext) -> CoreRsResult<()> {
     println!("daily executed: {}", context.name);
     Ok(())
 }

--- a/app/demo/src/main.rs
+++ b/app/demo/src/main.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 use framework::asset::asset_path;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::log;
 use framework::log::ConsoleAppender;
 use framework::shutdown::Shutdown;
@@ -17,7 +17,7 @@ mod web;
 pub struct AppState {}
 
 #[tokio::main]
-async fn main() -> Result<(), Exception> {
+async fn main() -> CoreRsResult<()> {
     log::init_with_action(ConsoleAppender);
 
     let shutdown = Shutdown::new();

--- a/app/demo/src/web.rs
+++ b/app/demo/src/web.rs
@@ -1,7 +1,7 @@
 use axum::Router;
 use axum::debug_handler;
 use axum::routing::post;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::validation_error;
 use framework::web::body::Json;
 use framework::web::error::HttpResult;
@@ -21,7 +21,7 @@ struct HelloRequest {
 }
 
 impl HelloRequest {
-    fn validate(&self) -> Result<(), Exception> {
+    fn validate(&self) -> CoreRsResult<()> {
         if self.message.len() > 10 {
             let exception = validation_error!(message = "message len must less than 10");
             warn!("test log, error={exception:?}");

--- a/app/log_collector/src/main.rs
+++ b/app/log_collector/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use framework::asset::asset_path;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::json;
 use framework::kafka::producer::Producer;
 use framework::kafka::topic::Topic;
@@ -28,7 +28,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    fn new(config: &AppConfig) -> Result<Self, Exception> {
+    fn new(config: &AppConfig) -> CoreRsResult<Self> {
         Ok(AppState {
             topics: Topics {
                 event: Topic::new("event"),
@@ -43,7 +43,7 @@ struct Topics {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Exception> {
+async fn main() -> CoreRsResult<()> {
     log::init_with_action(ConsoleAppender);
 
     let config: AppConfig = json::load_file(&asset_path("assets/conf.json")?)?;

--- a/app/log_collector/src/web.rs
+++ b/app/log_collector/src/web.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::result::Result;
 use std::sync::Arc;
 
 use axum::Extension;
@@ -16,7 +15,7 @@ use axum::routing::post;
 use chrono::DateTime;
 use chrono::Utc;
 use framework::exception;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::exception::Severity;
 use framework::exception::error_code;
 use framework::json;
@@ -185,7 +184,7 @@ impl Event {
     const MAX_INFO_VALUE_LENGTH: usize = 500_000;
     const MAX_ESTIMATED_LENGTH: usize = 900_000; // by default kafka message limit is 1M, leave 100k for rest of message
 
-    fn validate(&self) -> Result<(), Exception> {
+    fn validate(&self) -> CoreRsResult<()> {
         // Validate action for OK result
         if matches!(self.result, EventResult::Ok) && self.action.is_empty() {
             return Err(validation_error!(
@@ -220,7 +219,7 @@ impl Event {
         map: &HashMap<String, String>,
         max_key_length: usize,
         max_value_length: usize,
-    ) -> Result<usize, Exception> {
+    ) -> CoreRsResult<usize> {
         let mut estimated_length = 0;
         for (key, value) in map {
             if key.len() > max_key_length {
@@ -242,7 +241,7 @@ impl Event {
         Ok(estimated_length)
     }
 
-    fn validate_stats(stats: &HashMap<String, f64>, max_key_length: usize) -> Result<usize, Exception> {
+    fn validate_stats(stats: &HashMap<String, f64>, max_key_length: usize) -> CoreRsResult<usize> {
         let mut estimated_length = 0;
         for key in stats.keys() {
             if key.len() > max_key_length {

--- a/app/log_exporter/src/job.rs
+++ b/app/log_exporter/src/job.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use chrono::Days;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::schedule::JobContext;
 
 use crate::AppState;
 use crate::service::cleanup_archive;
 use crate::service::upload_archive;
 
-pub async fn process_log_job(state: Arc<AppState>, context: JobContext) -> Result<(), Exception> {
+pub async fn process_log_job(state: Arc<AppState>, context: JobContext) -> CoreRsResult<()> {
     let today = context.scheduled_time.date_naive();
     cleanup_archive(today.checked_sub_days(Days::new(5)).unwrap(), &state)?;
     upload_archive(today, &state).await?;

--- a/app/log_exporter/src/kafka/action_log_handler.rs
+++ b/app/log_exporter/src/kafka/action_log_handler.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::json;
 use framework::kafka::consumer::Message;
 use rdkafka::message::ToBytes;
@@ -49,7 +49,7 @@ pub struct PerformanceStatMessage {
 pub async fn action_log_message_handler(
     state: Arc<AppState>,
     messages: Vec<Message<ActionLogMessage>>,
-) -> Result<(), Exception> {
+) -> CoreRsResult<()> {
     let now = Utc::now().date_naive();
     let path = local_file_path("action", now, &state)?;
 

--- a/app/log_exporter/src/kafka/event_handler.rs
+++ b/app/log_exporter/src/kafka/event_handler.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::kafka::consumer::Message;
 use rdkafka::message::ToBytes;
 use serde::Deserialize;
@@ -32,10 +32,7 @@ pub struct EventMessage {
     info: HashMap<String, String>,
 }
 
-pub async fn event_message_handler(
-    state: Arc<AppState>,
-    messages: Vec<Message<EventMessage>>,
-) -> Result<(), Exception> {
+pub async fn event_message_handler(state: Arc<AppState>, messages: Vec<Message<EventMessage>>) -> CoreRsResult<()> {
     let now = Utc::now().date_naive();
     let path = local_file_path("event", now, &state)?;
 

--- a/app/log_exporter/src/main.rs
+++ b/app/log_exporter/src/main.rs
@@ -4,7 +4,7 @@ use axum::Router;
 use chrono::FixedOffset;
 use chrono::NaiveTime;
 use framework::asset::asset_path;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::json;
 use framework::kafka::consumer::ConsumerConfig;
 use framework::kafka::consumer::MessageConsumer;
@@ -45,7 +45,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    fn new(config: &AppConfig) -> Result<Self, Exception> {
+    fn new(config: &AppConfig) -> CoreRsResult<Self> {
         let hostname = hostname::get()?.to_string_lossy().to_string();
         let hash = &format!("{:x}", sha2::Sha256::digest(hostname))[0..6];
 
@@ -67,7 +67,7 @@ struct Topics {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Exception> {
+async fn main() -> CoreRsResult<()> {
     log::init_with_action(ConsoleAppender);
 
     let config: AppConfig = json::load_file(&asset_path("assets/conf.json")?)?;

--- a/app/log_exporter/src/service.rs
+++ b/app/log_exporter/src/service.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 
 use chrono::Datelike;
 use chrono::NaiveDate;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::shell;
 use tracing::info;
 
 use crate::AppState;
 
-pub fn local_file_path(name: &str, date: NaiveDate, state: &Arc<AppState>) -> Result<PathBuf, Exception> {
+pub fn local_file_path(name: &str, date: NaiveDate, state: &Arc<AppState>) -> CoreRsResult<PathBuf> {
     let dir = &state.log_dir;
     let year = date.year();
     let hash = &state.hash;
@@ -23,7 +23,7 @@ pub fn local_file_path(name: &str, date: NaiveDate, state: &Arc<AppState>) -> Re
     Ok(path)
 }
 
-pub fn cleanup_archive(date: NaiveDate, state: &Arc<AppState>) -> Result<(), Exception> {
+pub fn cleanup_archive(date: NaiveDate, state: &Arc<AppState>) -> CoreRsResult<()> {
     info!("clean up archives, date={date}");
 
     let action_log_path = local_file_path("action", date, state)?;
@@ -39,7 +39,7 @@ pub fn cleanup_archive(date: NaiveDate, state: &Arc<AppState>) -> Result<(), Exc
     Ok(())
 }
 
-pub async fn upload_archive(date: NaiveDate, state: &Arc<AppState>) -> Result<(), Exception> {
+pub async fn upload_archive(date: NaiveDate, state: &Arc<AppState>) -> CoreRsResult<()> {
     let action_log_path = local_file_path("action", date, state)?;
     if action_log_path.exists() {
         let remote_path = remote_path("action", date, state);
@@ -57,11 +57,7 @@ pub async fn upload_archive(date: NaiveDate, state: &Arc<AppState>) -> Result<()
     Ok(())
 }
 
-async fn convert_parquet_and_upload(
-    local_path_buf: PathBuf,
-    remote_path: &str,
-    columns: &str,
-) -> Result<(), Exception> {
+async fn convert_parquet_and_upload(local_path_buf: PathBuf, remote_path: &str, columns: &str) -> CoreRsResult<()> {
     let local_path = local_path_buf.to_string_lossy();
     info!("convert to parquet, path={local_path}");
     let parquet_path_buf = local_path_buf.with_extension("parquet");

--- a/app/log_processor/src/kafka/action_log_handler.rs
+++ b/app/log_processor/src/kafka/action_log_handler.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::kafka::consumer::Message;
 use serde::Deserialize;
 use serde::Serialize;
@@ -75,7 +75,7 @@ pub struct TraceDocument {
 pub async fn action_log_message_handler(
     state: Arc<AppState>,
     messages: Vec<Message<ActionLogMessage>>,
-) -> Result<(), Exception> {
+) -> CoreRsResult<()> {
     let mut documents: Vec<(String, ActionLogDocument)> = Vec::with_capacity(messages.len());
     let mut traces: Vec<(String, TraceDocument)> = vec![];
     for message in messages {

--- a/app/log_processor/src/kafka/event_handler.rs
+++ b/app/log_processor/src/kafka/event_handler.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::kafka::consumer::Message;
 use serde::Deserialize;
 use serde::Serialize;
@@ -27,9 +27,6 @@ pub struct EventMessage {
     info: HashMap<String, String>,
 }
 
-pub async fn event_message_handler(
-    _state: Arc<AppState>,
-    _messages: Vec<Message<EventMessage>>,
-) -> Result<(), Exception> {
+pub async fn event_message_handler(_state: Arc<AppState>, _messages: Vec<Message<EventMessage>>) -> CoreRsResult<()> {
     Ok(())
 }

--- a/app/log_processor/src/kibana.rs
+++ b/app/log_processor/src/kibana.rs
@@ -1,12 +1,12 @@
 use framework::exception;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::http::HeaderName;
 use framework::http::HttpClient;
 use framework::http::HttpMethod::POST;
 use framework::http::HttpRequest;
 use tracing::info;
 
-pub async fn import(kibana_uri: &str, objects: String) -> Result<(), Exception> {
+pub async fn import(kibana_uri: &str, objects: String) -> CoreRsResult<()> {
     let http_client = HttpClient::default();
     let mut request = HttpRequest::new(
         POST,

--- a/app/log_processor/src/main.rs
+++ b/app/log_processor/src/main.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::sync::Arc;
 
 use framework::asset::asset_path;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::json;
 use framework::kafka::consumer::ConsumerConfig;
 use framework::kafka::consumer::MessageConsumer;
@@ -33,7 +33,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    fn new(config: &AppConfig) -> Result<Self, Exception> {
+    fn new(config: &AppConfig) -> CoreRsResult<Self> {
         Ok(AppState {
             opensearch: Opensearch::new(&config.opensearch_uri),
         })
@@ -41,7 +41,7 @@ impl AppState {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Exception> {
+async fn main() -> CoreRsResult<()> {
     log::init_with_action(ConsoleAppender);
 
     let config: AppConfig = json::load_file(&asset_path("assets/conf.json")?)?;
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Exception> {
     Ok(())
 }
 
-async fn put_index_templates(opensearch: &Opensearch) -> Result<(), Exception> {
+async fn put_index_templates(opensearch: &Opensearch) -> CoreRsResult<()> {
     opensearch
         .put_index_template(
             "action",

--- a/app/log_processor/src/opensearch.rs
+++ b/app/log_processor/src/opensearch.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use framework::exception;
-use framework::exception::Exception;
+use framework::exception::CoreRsResult;
 use framework::http::HttpClient;
 use framework::http::HttpMethod::POST;
 use framework::http::HttpMethod::PUT;
@@ -22,7 +22,7 @@ impl Opensearch {
         }
     }
 
-    pub async fn put_index_template(&self, name: &str, template: String) -> Result<(), Exception> {
+    pub async fn put_index_template(&self, name: &str, template: String) -> CoreRsResult<()> {
         let uri = &self.uri;
         let mut request = HttpRequest::new(PUT, format!("{uri}/_index_template/{name}"));
         request.body(template, "application/json");
@@ -35,7 +35,7 @@ impl Opensearch {
         Ok(())
     }
 
-    pub async fn bulk_index<T>(&self, index: &str, documents: Vec<(String, T)>) -> Result<(), Exception>
+    pub async fn bulk_index<T>(&self, index: &str, documents: Vec<(String, T)>) -> CoreRsResult<()>
     where
         T: Serialize + Debug,
     {

--- a/lib/framework/src/asset.rs
+++ b/lib/framework/src/asset.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::exception;
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 
-pub fn asset_path(path: &str) -> Result<PathBuf, Exception> {
+pub fn asset_path(path: &str) -> CoreRsResult<PathBuf> {
     let exe_path = current_exe()?;
     let asset_path = find_asset_path(&exe_path, path);
     if asset_path.exists() {

--- a/lib/framework/src/exception.rs
+++ b/lib/framework/src/exception.rs
@@ -8,6 +8,8 @@ use serde::Serialize;
 
 pub mod error_code;
 
+pub type CoreRsResult<T> = Result<T, Exception>;
+
 pub struct Exception {
     pub severity: Severity,
     pub code: Option<String>,

--- a/lib/framework/src/fs/path.rs
+++ b/lib/framework/src/fs/path.rs
@@ -1,13 +1,13 @@
 use std::path::Path;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 
 pub trait PathExt {
-    fn file_extension(&self) -> Result<&str, Exception>;
+    fn file_extension(&self) -> CoreRsResult<&str>;
 }
 
 impl PathExt for Path {
-    fn file_extension(&self) -> Result<&str, Exception> {
+    fn file_extension(&self) -> CoreRsResult<&str> {
         self.extension()
             .ok_or_else(|| exception!(message = format!("file must have extension, path={}", self.to_string_lossy())))?
             .to_str()

--- a/lib/framework/src/fs/path_buf.rs
+++ b/lib/framework/src/fs/path_buf.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 
 pub trait PathBufExt {
-    fn into_absolute_path(self) -> Result<PathBuf, Exception>;
+    fn into_absolute_path(self) -> CoreRsResult<PathBuf>;
 }
 
 impl PathBufExt for PathBuf {
-    fn into_absolute_path(self) -> Result<PathBuf, Exception> {
+    fn into_absolute_path(self) -> CoreRsResult<PathBuf> {
         if self.is_absolute() {
             return Ok(self);
         }

--- a/lib/framework/src/http.rs
+++ b/lib/framework/src/http.rs
@@ -11,7 +11,7 @@ use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 
 pub struct HttpClient {
     client: reqwest::Client,
@@ -66,7 +66,7 @@ pub struct HttpResponse {
 }
 
 impl HttpClient {
-    pub async fn execute(&self, request: HttpRequest) -> Result<HttpResponse, Exception> {
+    pub async fn execute(&self, request: HttpRequest) -> CoreRsResult<HttpResponse> {
         let span = debug_span!("http_client", url = request.url, method = ?request.method);
         async {
             debug!(method = ?request.method, "[request]");

--- a/lib/framework/src/json.rs
+++ b/lib/framework/src/json.rs
@@ -6,9 +6,9 @@ use serde::Serialize;
 use serde::de::Deserialize;
 use serde::de::DeserializeOwned;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 
-pub fn load_file<T>(path: &Path) -> Result<T, Exception>
+pub fn load_file<T>(path: &Path) -> CoreRsResult<T>
 where
     T: DeserializeOwned,
 {
@@ -22,7 +22,7 @@ where
         .map_err(|err| exception!(message = format!("failed to deserialize, json={json}"), source = err))
 }
 
-pub fn from_json<'a, T>(json: &'a str) -> Result<T, Exception>
+pub fn from_json<'a, T>(json: &'a str) -> CoreRsResult<T>
 where
     T: Deserialize<'a>,
 {
@@ -30,7 +30,7 @@ where
         .map_err(|err| exception!(message = format!("failed to deserialize, json={json}"), source = err))
 }
 
-pub fn to_json<T>(object: &T) -> Result<String, Exception>
+pub fn to_json<T>(object: &T) -> CoreRsResult<String>
 where
     T: Serialize + Debug,
 {

--- a/lib/framework/src/kafka/producer.rs
+++ b/lib/framework/src/kafka/producer.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use tracing::debug_span;
 
 use super::topic::Topic;
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 use crate::json::to_json;
 use crate::log::current_action_id;
 
@@ -36,7 +36,7 @@ impl Producer {
         }
     }
 
-    pub async fn send<T>(&self, topic: &Topic<T>, key: Option<String>, message: &T) -> Result<(), Exception>
+    pub async fn send<T>(&self, topic: &Topic<T>, key: Option<String>, message: &T) -> CoreRsResult<()>
     where
         T: Serialize + Debug,
     {

--- a/lib/framework/src/log.rs
+++ b/lib/framework/src/log.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+use crate::exception::CoreRsResult;
 use crate::exception::Exception;
 use crate::exception::Severity;
 
@@ -87,7 +88,7 @@ macro_rules! log_event {
 
 pub async fn start_action<T>(action: &str, ref_id: Option<String>, task: T)
 where
-    T: Future<Output = Result<(), Exception>>,
+    T: Future<Output = CoreRsResult<()>>,
 {
     let action_id = id_generator::random_id();
     let action_span = info_span!("action", action, action_id, ref_id);

--- a/lib/framework/src/shell.rs
+++ b/lib/framework/src/shell.rs
@@ -4,9 +4,9 @@ use tracing::debug;
 use tracing::debug_span;
 
 use crate::exception;
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 
-pub async fn run(command: &str) -> Result<String, Exception> {
+pub async fn run(command: &str) -> CoreRsResult<String> {
     let span = debug_span!("shell", command);
 
     async {

--- a/lib/framework/src/task.rs
+++ b/lib/framework/src/task.rs
@@ -8,7 +8,7 @@ use tracing::Span;
 use tracing::debug;
 use tracing::info;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 use crate::log;
 use crate::log::current_action_id;
 
@@ -16,7 +16,7 @@ static TASK_TRACKER: LazyLock<TaskTracker> = LazyLock::new(TaskTracker::new);
 
 pub fn spawn_action<T>(name: &'static str, task: T)
 where
-    T: Future<Output = Result<(), Exception>> + Send + 'static,
+    T: Future<Output = CoreRsResult<()>> + Send + 'static,
 {
     let ref_id = current_action_id();
     TASK_TRACKER.spawn(async move {
@@ -28,9 +28,9 @@ where
     });
 }
 
-pub fn spawn_task<T>(task: T) -> JoinHandle<Result<(), Exception>>
+pub fn spawn_task<T>(task: T) -> JoinHandle<CoreRsResult<()>>
 where
-    T: Future<Output = Result<(), Exception>> + Send + 'static,
+    T: Future<Output = CoreRsResult<()>> + Send + 'static,
 {
     let span = Span::current();
     TASK_TRACKER.spawn(task.instrument(span))

--- a/lib/framework/src/web/body.rs
+++ b/lib/framework/src/web/body.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tracing::debug;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 use crate::exception::Severity;
 use crate::exception::error_code;
 use crate::json;
@@ -30,7 +30,7 @@ where
         match result {
             Ok(body) => {
                 debug!("[request] body={body}");
-                let body_object: Result<T, Exception> = json::from_json(&body);
+                let body_object: CoreRsResult<T> = json::from_json(&body);
                 match body_object {
                     Ok(value) => Ok(Self(value)),
                     Err(exception) => Err(exception!(

--- a/lib/framework/src/web/server.rs
+++ b/lib/framework/src/web/server.rs
@@ -18,7 +18,7 @@ pub use tower_http::services::ServeFile;
 use tracing::debug;
 use tracing::info;
 
-use crate::exception::Exception;
+use crate::exception::CoreRsResult;
 use crate::log;
 use crate::web::client_info::client_info;
 
@@ -40,7 +40,7 @@ pub async fn start_http_server(
     router: Router,
     mut shutdown_signal: broadcast::Receiver<()>,
     config: HttpServerConfig,
-) -> Result<(), Exception> {
+) -> CoreRsResult<()> {
     let app = Router::new();
     let app = app.merge(router);
     let app = app.layer(middleware::from_fn(http_server_layer));


### PR DESCRIPTION
Standardize error handling when using core-rs framework